### PR TITLE
Made Uuid taking functions take by reference

### DIFF
--- a/src/scene.rs
+++ b/src/scene.rs
@@ -51,7 +51,7 @@ impl<I: ImageSize> Scene<I> {
                     continue;
                 }
 
-                let sprite = self.child_mut(id.clone()).unwrap();
+                let sprite = self.child_mut(&id).unwrap();
                 let (status, _) = a.event(e, &mut |_, dt, animation, s| {
                     let (state, status, remain) = {
                         let start_state;
@@ -98,7 +98,7 @@ impl<I: ImageSize> Scene<I> {
         animations.push((animation.clone(), state, false));
     }
 
-    fn find(&self, sprite_id: Uuid, animation: &Behavior<Animation>) -> Option<usize> {
+    fn find(&self, sprite_id: &Uuid, animation: &Behavior<Animation>) -> Option<usize> {
         let mut index = None;
         if let Some(animations) = self.running.get(&sprite_id) {
             for i in 0..animations.len() {
@@ -113,8 +113,8 @@ impl<I: ImageSize> Scene<I> {
     }
 
     /// Pause a running animation of the sprite
-    pub fn pause(&mut self, sprite_id: Uuid, animation: &Behavior<Animation>) {
-        if let Some(index) = self.find(sprite_id.clone(), animation) {
+    pub fn pause(&mut self, sprite_id: &Uuid, animation: &Behavior<Animation>) {
+        if let Some(index) = self.find(sprite_id, animation) {
             let animations = self.running.get_mut(&sprite_id).unwrap();
             let (b, s, _) = animations.remove(index);
             animations.push((b, s, true));
@@ -122,8 +122,8 @@ impl<I: ImageSize> Scene<I> {
     }
 
     /// Resume a paused animation of the sprite
-    pub fn resume(&mut self, sprite_id: Uuid, animation: &Behavior<Animation>) {
-        if let Some(index) = self.find(sprite_id.clone(), animation) {
+    pub fn resume(&mut self, sprite_id: &Uuid, animation: &Behavior<Animation>) {
+        if let Some(index) = self.find(sprite_id, animation) {
             let animations = self.running.get_mut(&sprite_id).unwrap();
             let (b, s, _) = animations.remove(index);
             animations.push((b, s, false));
@@ -131,8 +131,8 @@ impl<I: ImageSize> Scene<I> {
     }
 
     /// Toggle an animation of the sprite
-    pub fn toggle(&mut self, sprite_id: Uuid, animation: &Behavior<Animation>) {
-        if let Some(index) = self.find(sprite_id.clone(), animation) {
+    pub fn toggle(&mut self, sprite_id: &Uuid, animation: &Behavior<Animation>) {
+        if let Some(index) = self.find(sprite_id, animation) {
             let animations = self.running.get_mut(&sprite_id).unwrap();
             let (b, s, paused) = animations.remove(index);
             animations.push((b, s, !paused));
@@ -140,14 +140,14 @@ impl<I: ImageSize> Scene<I> {
     }
 
     /// Stop a running animation of the sprite
-    pub fn stop(&mut self, sprite_id: Uuid, animation: &Behavior<Animation>) {
-        if let Some(index) = self.find(sprite_id.clone(), animation) {
+    pub fn stop(&mut self, sprite_id: &Uuid, animation: &Behavior<Animation>) {
+        if let Some(index) = self.find(sprite_id, animation) {
             self.running.get_mut(&sprite_id).unwrap().remove(index);
         }
     }
 
     /// Stop all running animations of the sprite
-    pub fn stop_all(&mut self, sprite_id: Uuid) {
+    pub fn stop_all(&mut self, sprite_id: &Uuid) {
         self.running.remove(&sprite_id);
     }
 
@@ -169,7 +169,7 @@ impl<I: ImageSize> Scene<I> {
     }
 
     fn stop_all_including_children(&mut self, sprite: &Sprite<I>) {
-        self.stop_all(sprite.id());
+        self.stop_all(&sprite.id());
         for child in sprite.children().iter() {
             self.stop_all_including_children(child);
         }
@@ -177,8 +177,8 @@ impl<I: ImageSize> Scene<I> {
 
     /// Remove the child by `id` from the scene's children or grandchild
     /// will stop all the animations run by this child
-    pub fn remove_child(&mut self, id: Uuid) -> Option<Sprite<I>> {
-        let removed = if let Some(index) = self.children_index.remove(&id) {
+    pub fn remove_child(&mut self, id: &Uuid) -> Option<Sprite<I>> {
+        let removed = if let Some(index) = self.children_index.remove(id) {
             let removed = self.children.remove(index);
             // Removing a element of vector will alter the index,
             // update the mapping from uuid to index.
@@ -204,8 +204,8 @@ impl<I: ImageSize> Scene<I> {
     }
 
     /// Find the child by `id` from the scene's children or grandchild
-    pub fn child(&self, id: Uuid) -> Option<&Sprite<I>> {
-        if let Some(index) = self.children_index.get(&id) {
+    pub fn child(&self, id: &Uuid) -> Option<&Sprite<I>> {
+        if let Some(index) = self.children_index.get(id) {
             Some(&self.children[*index])
         } else {
             for child in self.children.iter() {
@@ -218,8 +218,8 @@ impl<I: ImageSize> Scene<I> {
     }
 
     /// Find the child by `id` from this sprite's children or grandchild, mutability
-    pub fn child_mut(&mut self, id: Uuid) -> Option<&mut Sprite<I>> {
-        if let Some(index) = self.children_index.get(&id) {
+    pub fn child_mut(&mut self, id: &Uuid) -> Option<&mut Sprite<I>> {
+        if let Some(index) = self.children_index.get(id) {
             Some(&mut self.children[*index])
         } else {
             for child in self.children.iter_mut() {


### PR DESCRIPTION
This removes a lot of `.clones()` too! :balloon: 

I was wondering if the run function needs to take by reference also, but I will see when I update the sprite example in a few minutes.

closes #72 

~~~I made the run function take a reference, and its making me put in some lifetime annotations, so gimme a few minutes to fix everything else up ;)~~~ Good to go!