### PR TITLE
Adding Color Based Drawing

### DIFF
--- a/src/scene.rs
+++ b/src/scene.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use uuid::Uuid;
 
 use graphics::{ Graphics, ImageSize };
-use graphics::math::Matrix2d;
+use graphics::math::{ Matrix2d, Vec3d };
 
 use event::GenericEvent;
 use ai_behavior::{
@@ -87,6 +87,13 @@ impl<I: ImageSize> Scene<I> {
         }
     }
 
+    /// Render this scene with tint
+    pub fn draw_tinted<B: Graphics<Texture = I>>(&self, t: Matrix2d, b: &mut B, c: Vec3d) {
+        for child in self.children.iter() {
+            child.draw_tinted(t,b,c)
+        }
+    }
+
     /// Register animation with sprite
     pub fn run(&mut self, sprite_id: Uuid, animation: &Behavior<Animation>) {
         use std::collections::hash_map::Entry::{ Vacant, Occupied };
@@ -144,7 +151,7 @@ impl<I: ImageSize> Scene<I> {
         if let Some(index) = self.find(sprite_id, animation) {
             self.running.get_mut(&sprite_id).unwrap().remove(index);
         }
-    } 
+    }
 
     /// Stop all running animations of the sprite
     pub fn stop_all(&mut self, sprite_id: Uuid) {

--- a/src/sprite.rs
+++ b/src/sprite.rs
@@ -100,7 +100,6 @@ impl<I: ImageSize> Sprite<I> {
         self.position = [x, y];
     }
 
-/*
     /// Set the sprite's draw color (tint)
     #[inline(always)]
     pub fn set_color(&mut self, r: f64, g: f64, b: f64) {
@@ -112,7 +111,6 @@ impl<I: ImageSize> Sprite<I> {
     pub fn color(&self) -> (f64, f64, f64) {
         (self.color[0], self.color[1], self.color[2])
     }
-    */
 
     /// Get the sprite's rotation (in degree)
     #[inline(always)]

--- a/src/sprite.rs
+++ b/src/sprite.rs
@@ -44,7 +44,7 @@ impl<I: ImageSize> Sprite<I> {
             position: [0.0, 0.0],
             rotation: 0.0,
             scale: [1.0, 1.0],
-            color: [0.0,1.0,0.0],
+            color: [1.0,1.0,1.0],
 
             flip_x: false,
             flip_y: false,

--- a/src/sprite.rs
+++ b/src/sprite.rs
@@ -44,7 +44,7 @@ impl<I: ImageSize> Sprite<I> {
             position: [0.0, 0.0],
             rotation: 0.0,
             scale: [1.0, 1.0],
-            color: [1.0,0.0,0.0],
+            color: [1.0,1.0,0.0],
 
             flip_x: false,
             flip_y: false,

--- a/src/sprite.rs
+++ b/src/sprite.rs
@@ -285,7 +285,7 @@ impl<I: ImageSize> Sprite<I> {
         //model.rgb(1.0, 0.0, 0.0).draw(b);
 
         graphics::Image::new()
-            .color([self.color[0], self.color[1], self.color[2], self.opacity])
+            .color([self.color[0] as f32, self.color[1] as f32, self.color[2] as f32, self.opacity])
             .rect([-anchor[0], -anchor[1], w, h])
             .draw(&*self.texture, draw_state, model, b);
 

--- a/src/sprite.rs
+++ b/src/sprite.rs
@@ -44,7 +44,7 @@ impl<I: ImageSize> Sprite<I> {
             position: [0.0, 0.0],
             rotation: 0.0,
             scale: [1.0, 1.0],
-            color: [1.0,1.0,1.0],
+            color: [0.0,1.0,0.0],
 
             flip_x: false,
             flip_y: false,
@@ -100,17 +100,19 @@ impl<I: ImageSize> Sprite<I> {
         self.position = [x, y];
     }
 
+/*
     /// Set the sprite's draw color (tint)
     #[inline(always)]
     pub fn set_color(&mut self, r: f64, g: f64, b: f64) {
         self.color = [r, g, b];
     }
 
-    /// get the sprite's color.
+    /// get the sprite's color.s
     #[inline(always)]
     pub fn color(&self) -> (f64, f64, f64) {
         (self.color[0], self.color[1], self.color[2])
     }
+    */
 
     /// Get the sprite's rotation (in degree)
     #[inline(always)]

--- a/src/sprite.rs
+++ b/src/sprite.rs
@@ -44,7 +44,7 @@ impl<I: ImageSize> Sprite<I> {
             position: [0.0, 0.0],
             rotation: 0.0,
             scale: [1.0, 1.0],
-            color: [1.0,1.0,0.0],
+            color: [1.0,1.0,1.0],
 
             flip_x: false,
             flip_y: false,
@@ -100,6 +100,17 @@ impl<I: ImageSize> Sprite<I> {
         self.position = [x, y];
     }
 
+    /// Set the sprite's draw color (tint)
+    #[inline(always)]
+    pub fn set_color(&mut self, r: f64, g: f64, b: f64) {
+        self.color = [r, g, b];
+    }
+
+    /// get the sprite's color.
+    #[inline(always)]
+    pub fn color(&self) -> (f64, f64, f64) {
+        (self.color[0], self.color[1], self.color[2])
+    }
 
     /// Get the sprite's rotation (in degree)
     #[inline(always)]

--- a/src/sprite.rs
+++ b/src/sprite.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use uuid::Uuid;
 
 use graphics::{ self, Graphics, ImageSize };
-use graphics::math::{ Scalar, Matrix2d, Vec2d };
+use graphics::math::{ Scalar, Matrix2d, Vec2d, Vec3d };
 
 /// A sprite is a texture with some properties.
 pub struct Sprite<I: ImageSize> {
@@ -17,6 +17,8 @@ pub struct Sprite<I: ImageSize> {
     position: Vec2d,
     rotation: Scalar,
     scale: Vec2d,
+    color: Vec3d,
+
 
     flip_x: bool,
     flip_y: bool,
@@ -42,6 +44,7 @@ impl<I: ImageSize> Sprite<I> {
             position: [0.0, 0.0],
             rotation: 0.0,
             scale: [1.0, 1.0],
+            color: [1.0,0.0,0.0],
 
             flip_x: false,
             flip_y: false,
@@ -96,6 +99,7 @@ impl<I: ImageSize> Sprite<I> {
     pub fn set_position(&mut self, x: Scalar, y: Scalar) {
         self.position = [x, y];
     }
+
 
     /// Get the sprite's rotation (in degree)
     #[inline(always)]
@@ -281,7 +285,7 @@ impl<I: ImageSize> Sprite<I> {
         //model.rgb(1.0, 0.0, 0.0).draw(b);
 
         graphics::Image::new()
-            .color([1.0, 1.0, 1.0, self.opacity])
+            .color([self.color[0], self.color[1], self.color[2], self.opacity])
             .rect([-anchor[0], -anchor[1], w, h])
             .draw(&*self.texture, draw_state, model, b);
 


### PR DESCRIPTION
I was messing around with game dev in Rust during Ludum Dare and wanted some simple color manipulation (sprite tinting).  After digging into the library, I noticed it was pretty easy to implement.  I just added a simple color property as a Vec3d for r,g,b values to sprite and modifiied the draw value to use it (it will default to white (1,1,1) so the property can be ignored for default drawing).  Also added a function to scene to draw all objects with a specified tint and a function to sprite to draw with a color instead of setting the color property.  Figured someone else might be able to use these features, hence the pull request.