### PR TITLE
Add remove_child_when_done and running_for_child to Scene.

### DIFF
--- a/tests/fake_texture.rs
+++ b/tests/fake_texture.rs
@@ -1,0 +1,16 @@
+extern crate graphics;
+
+use self::graphics::ImageSize;
+
+pub struct FakeTexture;
+
+impl FakeTexture {
+    pub fn new() -> Self { FakeTexture }
+}
+
+impl ImageSize for FakeTexture {
+    fn get_size(&self) -> (u32, u32) { (32, 32) }
+    fn get_width(&self) -> (u32) { 32 }
+    fn get_height(&self) -> (u32) { 32 }
+}
+

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,0 +1,71 @@
+mod fake_texture;
+
+extern crate sprite;
+extern crate ai_behavior;
+extern crate input;
+extern crate graphics;
+
+use std::rc::Rc;
+use ai_behavior::{Action};
+
+use sprite::*;
+use fake_texture::FakeTexture;
+
+#[test]
+fn pruning_stopped_sprites() {
+    let mut scene: Scene<FakeTexture> = Scene::new();
+    let sprite = Sprite::from_texture(Rc::new(FakeTexture::new()));
+
+    let id = scene.add_child(sprite);
+    assert_eq!(0, scene.running_for_child(id).unwrap());
+
+    // Add a 1s animation to the sprite
+    scene.run(id, &Action(FadeOut(1.0)));
+    assert_eq!(1, scene.running_for_child(id).unwrap());
+
+    // Schedule sprite for removal
+    scene.remove_child_when_done(id);
+    assert!(scene.child(id).is_some()); // Hasn't been removed yet!
+
+    scene.event(&dt_event(0.9)); // Advance to just before animation finishes
+
+    assert_eq!(1, scene.running_for_child(id).unwrap());
+    assert!(scene.child(id).is_some()); // Hasn't been removed yet!
+
+    scene.event(&dt_event(0.2)); // Advance past the end of the animation
+
+    assert!(scene.child(id).is_none()); // Now it is removed
+    assert!(scene.running_for_child(id).is_none());
+}
+
+#[test]
+fn remove_child_when_done_when_sprite_already_stopped() {
+    let mut scene: Scene<FakeTexture> = Scene::new();
+    let sprite = Sprite::from_texture(Rc::new(FakeTexture::new()));
+
+    let id = scene.add_child(sprite);
+    scene.remove_child_when_done(id);
+
+    assert!(scene.child(id).is_none());
+}
+
+#[test]
+fn remove_child_when_done_when_animations_paused() {
+    let mut scene: Scene<FakeTexture> = Scene::new();
+    let sprite = Sprite::from_texture(Rc::new(FakeTexture::new()));
+
+    let id = scene.add_child(sprite);
+    let animation = Action(FadeOut(1.0));
+    scene.run(id, &animation);
+    scene.pause(id, &animation);
+    scene.remove_child_when_done(id);
+
+    assert!(scene.child(id).is_some());
+}
+
+fn dt_event(dt: f64) -> input::Event {
+    let event = input::Event::Update(input::UpdateArgs { dt: 0.0 });
+    let event: input::Event = input::UpdateEvent::from_dt(dt, &event).unwrap();
+
+    event
+}


### PR DESCRIPTION
This allows client code to monitor the state of sprites to wait for
animations to complete, or to set an automated cleanup to remove the
sprite once done.

Fixes #113 

I took the liberty of adding a `tests` directory. I'm not sure what the rust recommended way to do this (I'm just following [the book](https://doc.rust-lang.org/book/testing.html)) but I wanted some way to verify this does what I was expecting.