### PR TITLE
Add an accessor for a scene's children.

### DIFF
--- a/src/scene.rs
+++ b/src/scene.rs
@@ -292,4 +292,10 @@ impl<I: ImageSize> Scene<I> {
             None
         }
     }
+
+    /// Get the list of top-level (non-child) sprites.
+    #[inline(always)]
+    pub fn children(&self) -> &Vec<Sprite<I>> {
+        &self.children
+    }
 }


### PR DESCRIPTION
I am using this for experimentation with alternate drawing algorithms,
such as adding clipping, but seems likely to be other uses.